### PR TITLE
feat: 添加通过 Base 选项比对 profile 文件的示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # go-pprof-practice
 
 - [《golang pprof 实战》](https://blog.wolfogre.com/posts/go-ppof-practice/)代码实验用例。
-- [《Go性能分析工具》](http://blog.farmer233.top/2023/07/04/Go%E6%80%A7%E8%83%BD%E5%88%86%E6%9E%90%E5%B7%A5%E5%85%B7/)代码实验用例。
+- [《Go性能分析工具》](https://farmerchillax.github.io/2023/07/04/Go%E6%80%A7%E8%83%BD%E5%88%86%E6%9E%90%E5%B7%A5%E5%85%B7/)代码实验用例。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # go-pprof-practice
 
-[《golang pprof 实战》](https://blog.wolfogre.com/posts/go-ppof-practice/)代码实验用例。
-[《Go性能分析工具》](http://blog.farmer233.top/2023/07/04/Go%E6%80%A7%E8%83%BD%E5%88%86%E6%9E%90%E5%B7%A5%E5%85%B7/)代码实验用例。
+- [《golang pprof 实战》](https://blog.wolfogre.com/posts/go-ppof-practice/)代码实验用例。
+- [《Go性能分析工具》](http://blog.farmer233.top/2023/07/04/Go%E6%80%A7%E8%83%BD%E5%88%86%E6%9E%90%E5%B7%A5%E5%85%B7/)代码实验用例。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # go-pprof-practice
 
 [《golang pprof 实战》](https://blog.wolfogre.com/posts/go-ppof-practice/)代码实验用例。
+[《Go性能分析工具》](http://blog.farmer233.top/2023/07/04/Go%E6%80%A7%E8%83%BD%E5%88%86%E6%9E%90%E5%B7%A5%E5%85%B7/)代码实验用例。

--- a/animal/muridae/mouse/mouse.go
+++ b/animal/muridae/mouse/mouse.go
@@ -2,12 +2,14 @@ package mouse
 
 import (
 	"log"
+	"time"
 
 	"github.com/wolfogre/go-pprof-practice/constant"
 )
 
 type Mouse struct {
-	buffer [][constant.Mi]byte
+	buffer     [][constant.Mi]byte
+	slowBuffer [][constant.Mi]byte
 }
 
 func (*Mouse) Name() string {
@@ -37,6 +39,14 @@ func (m *Mouse) Shit() {
 
 func (m *Mouse) Pee() {
 	log.Println(m.Name(), "pee")
+	go func() {
+		time.Sleep(time.Second * 10)
+		max := constant.Gi
+		for len(m.slowBuffer)*constant.Mi < max {
+			m.slowBuffer = append(m.slowBuffer, [constant.Mi]byte{})
+			time.Sleep(time.Millisecond * 500)
+		}
+	}()
 }
 
 func (m *Mouse) Hole() {

--- a/animal/muridae/mouse/mouse.go
+++ b/animal/muridae/mouse/mouse.go
@@ -40,7 +40,7 @@ func (m *Mouse) Shit() {
 func (m *Mouse) Pee() {
 	log.Println(m.Name(), "pee")
 	go func() {
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 30)
 		max := constant.Gi
 		for len(m.slowBuffer)*constant.Mi < max {
 			m.slowBuffer = append(m.slowBuffer, [constant.Mi]byte{})


### PR DESCRIPTION
有许多问题是无法立即找到的，往往需要一定的时间才会暴露出来（比如缓慢的内存泄漏），而 pprof 工具的 base 选项能很好的帮助我们排查问题。
在阅读的过程中我发现本文缺少了对该选项的描述，为此我添加了 base 选项的 demo 与相对应的实战示例。
